### PR TITLE
Updating require for BrowserWindow to Work

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const queryString = require('querystring');
 const fetch = require('node-fetch');
 const objectAssign = require('object-assign');
 const electron = require('electron');
-const BrowserWindow = electron.remote.BrowserWindow;
+const {BrowserWindow} = require('electron');
 
 module.exports = function (config, windowParams) {
   function getAuthorizationCode(opts) {


### PR DESCRIPTION
This fixes for latest Electron: 1.1.1

On latest Electron, immediately when requiring this module got:

```
Error:
> electron .

App threw an error when running TypeError: Cannot read property 'BrowserWindow' of undefined
    at Object.<anonymous> (/app/node_modules/electron-oauth2/index.js:6:51)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/app/index.js:5:24)
    at Module._compile (module.js:541:32)
```
