### PR TITLE
Allow passing additional data to getAccessToken()

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,11 +99,13 @@ module.exports = function (config, windowParams) {
   function getAccessToken(opts) {
     return getAuthorizationCode(opts)
       .then(authorizationCode => {
-        return tokenRequest({
+        var tokenRequestData = {
           code: authorizationCode,
           grant_type: 'authorization_code',
           redirect_uri: config.redirectUri
-        });
+        }
+        tokenRequestData = Object.assign(tokenRequestData, opts.additionalTokenRequestData);
+        return tokenRequest(tokenRequestData);
       });
   }
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = function (config, windowParams) {
           code: authorizationCode,
           grant_type: 'authorization_code',
           redirect_uri: config.redirectUri
-        }
+        };
         tokenRequestData = Object.assign(tokenRequestData, opts.additionalTokenRequestData);
         return tokenRequest(tokenRequestData);
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-oauth2",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "An OAuth2 module for your Electron app.",
   "license": "MIT",
   "repository": "mawie81/electron-oauth2",
@@ -23,7 +23,7 @@
   ],
   "devDependencies": {
     "ava": "^0.8.0",
-    "electron": "^0.4.1",
+    "electron": "^1.4.1",
     "mocha": "^2.5.3",
     "xo": "^0.12.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-oauth2",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "description": "An OAuth2 module for your Electron app.",
   "license": "MIT",
   "repository": "mawie81/electron-oauth2",

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,10 @@ The optional OAuth2 scopes.
 Type: `String`
 The optional OAuth2 access type.
 
+###### additionalTokenRequestData
+Type: `Object`
+The optional additional parameters to pass to the server in the body of the token request.
+
 #### getAuthorizationCode(options)
 
 Returns a ```Promise``` that gets resolved with the authorization code of the OAuth2 authorization request.


### PR DESCRIPTION
This enables scenarios including the use of this library to authenticate with Azure Active Directory.