### PR TITLE
URL of the authorization token has "approvalCode" attribute instead o…

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function (config, windowParams) {
       function onCallback(url) {
         var url_parts = nodeUrl.parse(url, true);
         var query = url_parts.query;
-        var code = query.code;
+        var code = query.approvalCode;
         var error = query.error;
 
         if (error !== undefined) {


### PR DESCRIPTION
…f "code".

I have tested the original repo and it seems that when `onCallback` is executed, the parsed url returned from google with the authorization code does not contain an attribute called `code`, but a new attribute called `approvedCode` which represents the authorization code in the window url. I updated the repo to read that attribute so that the code from line `69` to `74` is executed accordingly.