### PR TITLE
Fix Grant Code retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
 
-var generateRandomString = function(length) {
-    var text = '';
-    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+var generateRandomString = function (length) {
+  var text = '';
+  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-    for (var i = 0; i < length; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
+  for (var i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+
+  return text;
 };
 
 module.exports = function (config, windowParams) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
 
+var generateRandomString = function(length) {
+    var text = '';
+    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (var i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+};
+
 module.exports = function (config, windowParams) {
   function getAuthorizationCode(opts) {
     opts = opts || {};
@@ -19,7 +29,8 @@ module.exports = function (config, windowParams) {
     var urlParams = {
       response_type: 'code',
       redirect_uri: config.redirectUri,
-      client_id: config.clientId
+      client_id: config.clientId,
+      state: generateRandomString(16)
     };
 
     if (opts.scope) {


### PR DESCRIPTION
The original code does not work in the case of brokered OIDC as it just looks for the grant code to show up as url param in one of the redirects. In the brokered OIDC scenario the broker can have a temporary code show up in the middle of the flow. e.g. if I setup a identity broker flow in Keycloak, keycloak uses a temporary code before the actual auth happens with configured OIDC IDP. In such a case, wrong code is used to request token

In this enhancement, code is retrieved only when the redirect url is corresponding to the redirect uri configured. This would work in both single IDP and brokered IDP scenario