### PR TITLE
Fix Grant Code retrieval

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const objectAssign = require('object-assign');
 const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
-const { ipcMain } = require("electron");
-const path = require("path");
+const {ipcMain} = require('electron');
+const path = require('path');
 
 var generateRandomString = function (length) {
   var text = '';
@@ -62,15 +62,15 @@ module.exports = function (config, windowParams) {
         promptOptions = options;
         promptWindow = new BrowserWindow({
           width: 300, height: 150,
-          'parent': parent,
-          'show': true,
-          'modal': true,
-          'alwaysOnTop': true,
-          'title': options.title,
-          'autoHideMenuBar': true,
-          'webPreferences': {
-            "nodeIntegration": true,
-            "sandbox": false
+          parent: parent,
+          show: true,
+          modal: true,
+          alwaysOnTop: true,
+          title: options.title,
+          autoHideMenuBar: true,
+          webPreferences: {
+            nodeIntegration: true,
+            sandbox: false
           }
         });
 
@@ -88,14 +88,14 @@ module.exports = function (config, windowParams) {
       }
 
       // Called by the dialog box to get its parameters
-      ipcMain.on("openDialog", event => {
+      ipcMain.on('openDialog', event => {
         event.returnValue = JSON.stringify(promptOptions, null, '');
-      })
+      });
 
       // Called by the dialog box when closed
-      ipcMain.on("closeDialog", (event, data) => {
+      ipcMain.on('closeDialog', (event, data) => {
         promptAnswer = data;
-      })
+      });
 
       authWindow.loadURL(url);
       authWindow.show();
@@ -152,13 +152,12 @@ module.exports = function (config, windowParams) {
         event.preventDefault();
 
         promptModal(authWindow, {
-          "label": "Login to " + authInfo.host + " :",
+          label: 'Login to ' + authInfo.host + ' :'
         },
           function (data) {
             if (data) {
               callback(data.username, data.password);
-            }
-            else {
+            } else {
               onCallback(null, new Error('User cancelled authentication'));
             }
           }

--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
 
-var generateRandomString = function(length) {
-    var text = '';
-    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+var generateRandomString = function (length) {
+  var text = '';
+  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-    for (var i = 0; i < length; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
+  for (var i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+
+  return text;
 };
 
 module.exports = function (config, windowParams) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
 
+var generateRandomString = function(length) {
+    var text = '';
+    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (var i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+};
+
 module.exports = function (config, windowParams) {
   function getAuthorizationCode(opts) {
     opts = opts || {};
@@ -19,7 +29,8 @@ module.exports = function (config, windowParams) {
     var urlParams = {
       response_type: 'code',
       redirect_uri: config.redirectUri,
-      client_id: config.clientId
+      client_id: config.clientId,
+      state: generateRandomString(16)
     };
 
     if (opts.scope) {

--- a/prompt.html
+++ b/prompt.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta charset=utf-8>
+        <title>Login</title>
+    </head>
+    <body>
+        <p id="label"></p>
+        <p>
+            <input type="text" id="username" value="" placeholder="User Name">
+            <input type="password" id="password" value="" placeholder="Password">
+        </p>
+        <p>
+            <input type = "button" id="ok" value="Login" onclick="response()">
+            <input type = "button" value="Cancel" onclick="cancel()">
+        </p>
+        <script>
+        const { ipcRenderer } = require("electron");
+
+        function cancel() {
+            ipcRenderer.send("closeDialog", null);
+            this.close();
+        }
+
+        function response() {
+            ipcRenderer.send("closeDialog", 
+                { 
+                    username: document.getElementById("username").value, 
+                    password: document.getElementById("password").value 
+                });
+            this.close();
+        }
+        
+        window.onload=function() {
+            var options = ipcRenderer.sendSync("openDialog", "");
+            var params = JSON.parse(options);
+            document.getElementById("label").innerHTML = params.label;   
+        }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The original code does not work in the case of brokered OIDC as it just looks for the grant code to show up as url param in one of the redirects. In the brokered OIDC scenario the broker can have a temporary code show up in the middle of the flow. e.g. if I setup a identity broker flow in Keycloak, keycloak uses a temporary code before the actual auth happens with configured OIDC IDP. In such a case, wrong code is used to request token

In this enhancement, code is retrieved only when the redirect url is corresponding to the redirect uri configured. This would work in both single IDP and brokered IDP scenario

In addition, login event handler has been added for cases where browser would have shown http basic auth popup instead of login page. This occurs in the case of brokered OIDC where Windows Integrated Authentication is triggered.