### PR TITLE
Fix Grant Code retrieval with login event handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const objectAssign = require('object-assign');
 const nodeUrl = require('url');
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
+const {ipcMain} = require('electron');
+const path = require('path');
 
 var generateRandomString = function (length) {
   var text = '';
@@ -47,6 +49,54 @@ module.exports = function (config, windowParams) {
     return new Promise(function (resolve, reject) {
       const authWindow = new BrowserWindow(windowParams || {'use-content-size': true});
 
+      let receivedCode = false;
+      let receivedError = false;
+
+      /* DIALOG BOX PART */
+      var promptWindow;
+      var promptOptions;
+      var promptAnswer;
+
+      // Clearing the dialog
+      function promptModal(parent, options, callback) {
+        promptOptions = options;
+        promptWindow = new BrowserWindow({
+          width: 300, height: 150,
+          parent: parent,
+          show: true,
+          modal: true,
+          alwaysOnTop: true,
+          title: options.title,
+          autoHideMenuBar: true,
+          webPreferences: {
+            nodeIntegration: true,
+            sandbox: false
+          }
+        });
+
+        promptWindow.on('closed', () => {
+          promptWindow = null;
+          callback(promptAnswer);
+        });
+
+        // Load the HTML dialog box
+        promptWindow.loadURL(nodeUrl.format({
+          pathname: path.join(__dirname, 'prompt.html'),
+          protocol: 'file:',
+          slashes: true
+        }));
+      }
+
+      // Called by the dialog box to get its parameters
+      ipcMain.on('openDialog', event => {
+        event.returnValue = JSON.stringify(promptOptions, null, '');
+      });
+
+      // Called by the dialog box when closed
+      ipcMain.on('closeDialog', (event, data) => {
+        promptAnswer = data;
+      });
+
       authWindow.loadURL(url);
       authWindow.show();
 
@@ -54,26 +104,65 @@ module.exports = function (config, windowParams) {
         reject(new Error('window was closed by user'));
       });
 
-      function onCallback(url) {
+      function closeAuthWindow() {
+        authWindow.removeAllListeners();
+        setImmediate(function () {
+          authWindow.close();
+        });
+      }
+
+      function onCallback(url, err) {
+        if (receivedCode || receivedError) {
+          return;
+        }
+
+        if (err) {
+          receivedError = true;
+          reject(err);
+          closeAuthWindow();
+          return;
+        }
+
         var url_parts = nodeUrl.parse(url, true);
         var query = url_parts.query;
-        var code = query.code;
+        var code = null;
         var error = query.error;
 
+        // Grant code should be captured only from the redirect uri specified in the config
+        // This allows for multiple brokers in OIDC chain which may url parameter with name code
+        if (url.startsWith(config.redirectUri + '?') ||
+          url.startsWith(config.redirectUri + '/?')) {
+          code = query.code;
+        }
+
         if (error !== undefined) {
+          receivedError = true;
           reject(error);
-          authWindow.removeAllListeners('closed');
-          setImmediate(function () {
-            authWindow.close();
-          });
+          closeAuthWindow();
+          return;
         } else if (code) {
+          receivedCode = true;
           resolve(code);
-          authWindow.removeAllListeners('closed');
-          setImmediate(function () {
-            authWindow.close();
-          });
+          closeAuthWindow();
+          return;
         }
       }
+
+      authWindow.webContents.on('login', (event, request, authInfo, callback) => {
+        event.preventDefault();
+
+        promptModal(authWindow, {
+          label: 'Login to ' + authInfo.host + ' :'
+        },
+          function (data) {
+            if (data) {
+              callback(data.username, data.password);
+            } else {
+              onCallback(null, new Error('User cancelled authentication'));
+            }
+          }
+        );
+      });
 
       authWindow.webContents.on('will-navigate', (event, url) => {
         onCallback(url);

--- a/index.js
+++ b/index.js
@@ -96,14 +96,14 @@ module.exports = function (config, windowParams) {
       ipcMain.on('closeDialog', (event, data) => {
         promptAnswer = data;
       });
-      
+
       // If the certificate used for TLS in any redirects is not trusted,
       // handle it here. Default behavior is hung app with white screen
-      authWindow.webContents.on('certificate-error', (event, url, error, certificate, callback) => {
+      authWindow.webContents.on('certificate-error', (event, url) => {
         authWindow.hide();
         reject(new Error('Certificate presented for ' + url + ' is not trusted'));
       });
-      
+
       authWindow.loadURL(url);
       authWindow.show();
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,14 @@ module.exports = function (config, windowParams) {
       ipcMain.on('closeDialog', (event, data) => {
         promptAnswer = data;
       });
-
+      
+      // If the certificate used for TLS in any redirects is not trusted,
+      // handle it here. Default behavior is hung app with white screen
+      authWindow.webContents.on('certificate-error', (event, url, error, certificate, callback) => {
+        authWindow.hide();
+        reject(new Error('Certificate presented for ' + url + ' is not trusted'));
+      });
+      
       authWindow.loadURL(url);
       authWindow.show();
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "marcel.wiehle.me"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "prompt.html"
   ],
   "scripts": {
     "test": "xo"

--- a/prompt.html
+++ b/prompt.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta charset=utf-8>
+        <title>Login</title>
+    </head>
+    <body>
+        <p id="label"></p>
+        <p>
+            <input type="text" id="username" value="" placeholder="User Name">
+            <input type="password" id="password" value="" placeholder="Password">
+        </p>
+        <p>
+            <input type = "button" id="ok" value="Login" onclick="response()">
+            <input type = "button" value="Cancel" onclick="cancel()">
+        </p>
+        <script>
+        const { ipcRenderer } = require("electron");
+
+        function cancel() {
+            ipcRenderer.send("closeDialog", null);
+            this.close();
+        }
+
+        function response() {
+            ipcRenderer.send("closeDialog", 
+                { 
+                    username: document.getElementById("username").value, 
+                    password: document.getElementById("password").value 
+                });
+            this.close();
+        }
+        
+        window.onload=function() {
+            var options = ipcRenderer.sendSync("openDialog", "");
+            var params = JSON.parse(options);
+            document.getElementById("label").innerHTML = params.label;   
+        }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The original code does not work in the case of brokered OIDC as it just looks for the grant code to show up as url param in one of the redirects. In the brokered OIDC scenario the broker can have a temporary code show up in the middle of the flow. e.g. if I setup a identity broker flow in Keycloak, keycloak uses a temporary code before the actual auth happens with configured OIDC IDP. In such a case, wrong code is used to request token

In this enhancement, code is retrieved only when the redirect url is corresponding to the redirect uri configured. This would work in both single IDP and brokered IDP scenario

In addition, **login** event handler has been added for cases where browser would have shown http basic auth popup instead of login page. This occurs in the case of brokered OIDC where Windows Integrated Authentication is triggered.