### PR TITLE
Allow additional parameters for Authorization Code request

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (config, windowParams) {
       response_type: 'code',
       redirect_uri: config.redirectUri,
       client_id: config.clientId,
-      state: generateRandomString(16)
+      state: generateRandomString(16),
     };
 
     if (opts.scope) {
@@ -41,6 +41,8 @@ module.exports = function (config, windowParams) {
     if (opts.accessType) {
       urlParams.access_type = opts.accessType;
     }
+
+    urlParams = Object.assign(urlParams, opts.additionalAuthCodeRequestData);
 
     var url = config.authorizationUrl + '?' + queryString.stringify(urlParams);
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (config, windowParams) {
       response_type: 'code',
       redirect_uri: config.redirectUri,
       client_id: config.clientId,
-      state: generateRandomString(16),
+      state: generateRandomString(16)
     };
 
     if (opts.scope) {

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,10 @@ The optional OAuth2 scopes.
 Type: `String`
 The optional OAuth2 access type.
 
+###### additionalAuthCodeRequestData
+Type: `Object`
+The optional additional parameters to pass to the server in the body of the authorization code request.
+
 ###### additionalTokenRequestData
 Type: `Object`
 The optional additional parameters to pass to the server in the body of the token request.


### PR DESCRIPTION
Google's OAuth2 API allows additional parameters such as
`prompt=consent` to be passed when making the Authorization Code
request. This change allows the user to specify additional parameters
for the Authorization Code request, similar to how users can already
define additional parameters for the subsequent Access Token request.

Google documentation: https://developers.google.com/identity/protocols/OAuth2WebServer#creatingclient Note the parameters `state`, `include_granted_scopes`, `login_hint`, and `prompt` parameters. With Google's API they wont pass back a refresh_token after the first time a user OAuth unless you pass prompt=consent, so this functionality is pretty critical if you want to use electron-oauth2 with Google and have reliable refresh tokens.

Thanks so much for the time you put into making this library public! It's way better than the hacky code I had before.