### PR TITLE
Prevent error when two BrowserWindow events collide; Reduce window flashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ module.exports = function (config, windowParams) {
 
       authWindow.loadURL(url);
       authWindow.once('ready-to-show', () => {
-        authWindow.show()
-      })
+        authWindow.show();
+      });
       
 
       authWindow.on('closed', () => {

--- a/index.js
+++ b/index.js
@@ -64,13 +64,17 @@ module.exports = function (config, windowParams) {
           reject(error);
           authWindow.removeAllListeners('closed');
           setImmediate(function () {
-            authWindow.close();
+            if(!authWindow.isDestroyed()){
+              authWindow.close();
+            }
           });
         } else if (code) {
           resolve(code);
           authWindow.removeAllListeners('closed');
           setImmediate(function () {
-            authWindow.close();
+           if(!authWindow.isDestroyed()){
+              authWindow.close();
+            }
           });
         }
       }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,10 @@ module.exports = function (config, windowParams) {
       const authWindow = new BrowserWindow(windowParams || {'use-content-size': true});
 
       authWindow.loadURL(url);
-      authWindow.show();
+      authWindow.once('ready-to-show', () => {
+        authWindow.show()
+      })
+      
 
       authWindow.on('closed', () => {
         reject(new Error('window was closed by user'));


### PR DESCRIPTION
- When trying to use the Microsoft(azure/graph) oAuth, the BrowserWindow would trigger the two events, leading to the module trying to close the Window twice causing an error.

- Again with Microsoft oAuth, you have a option to remember the user, if the user wants to have always the session already signed in. The BrowserWindow would open for just 2 seconds and then close(Window Flashing).

